### PR TITLE
Fix for NextJS v13: Remove <a> tags inside of <Link> tags

### DIFF
--- a/components/appbar.tsx
+++ b/components/appbar.tsx
@@ -10,30 +10,29 @@ const Appbar = () => {
 	const router = useRouter()
 
 	return (
-		<div className='fixed top-0 left-0 z-20 w-full bg-zinc-900 pt-safe'>
+        <div className='fixed top-0 left-0 z-20 w-full bg-zinc-900 pt-safe'>
 			<header className='border-b bg-zinc-100 px-safe dark:border-zinc-800 dark:bg-zinc-900'>
 				<div className='mx-auto flex h-20 max-w-screen-md items-center justify-between px-6'>
 					<Link href='/'>
-						<a>
-							<h1 className='font-medium'>Rice Bowl</h1>
-						</a>
-					</Link>
+                        <h1 className='font-medium'>Rice Bowl</h1>
+                    </Link>
 
 					<nav className='flex items-center space-x-6'>
 						<div className='hidden sm:block'>
 							<div className='flex items-center space-x-6'>
 								{links.map(({ label, href }) => (
-									<Link key={label} href={href}>
-										<a
-											className={`text-sm ${
-												router.pathname === href
-													? 'text-indigo-500 dark:text-indigo-400'
-													: 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
-											}`}
-										>
-											{label}
-										</a>
-									</Link>
+									(<Link
+                                        key={label}
+                                        href={href}
+                                        className={`text-sm ${
+                                            router.pathname === href
+                                                ? 'text-indigo-500 dark:text-indigo-400'
+                                                : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+                                        }`}>
+
+                                        {label}
+
+                                    </Link>)
 								))}
 							</div>
 						</div>
@@ -50,7 +49,7 @@ const Appbar = () => {
 				</div>
 			</header>
 		</div>
-	)
+    )
 }
 
 export default Appbar

--- a/components/appbar.tsx
+++ b/components/appbar.tsx
@@ -10,29 +10,28 @@ const Appbar = () => {
 	const router = useRouter()
 
 	return (
-        <div className='fixed top-0 left-0 z-20 w-full bg-zinc-900 pt-safe'>
+		<div className='fixed top-0 left-0 z-20 w-full bg-zinc-900 pt-safe'>
 			<header className='border-b bg-zinc-100 px-safe dark:border-zinc-800 dark:bg-zinc-900'>
 				<div className='mx-auto flex h-20 max-w-screen-md items-center justify-between px-6'>
 					<Link href='/'>
-                        <h1 className='font-medium'>Rice Bowl</h1>
-                    </Link>
+						<h1 className='font-medium'>Rice Bowl</h1>
+					</Link>
 
 					<nav className='flex items-center space-x-6'>
 						<div className='hidden sm:block'>
 							<div className='flex items-center space-x-6'>
 								{links.map(({ label, href }) => (
-									(<Link
-                                        key={label}
-                                        href={href}
-                                        className={`text-sm ${
-                                            router.pathname === href
-                                                ? 'text-indigo-500 dark:text-indigo-400'
-                                                : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
-                                        }`}>
-
-                                        {label}
-
-                                    </Link>)
+									<Link
+										key={label}
+										href={href}
+										className={`text-sm ${
+											router.pathname === href
+												? 'text-indigo-500 dark:text-indigo-400'
+												: 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+										}`}
+									>
+										{label}
+									</Link>
 								))}
 							</div>
 						</div>
@@ -49,7 +48,7 @@ const Appbar = () => {
 				</div>
 			</header>
 		</div>
-    )
+	)
 }
 
 export default Appbar

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -5,29 +5,30 @@ const BottomNav = () => {
 	const router = useRouter()
 
 	return (
-		<div className='sm:hidden'>
+        <div className='sm:hidden'>
 			<nav className='fixed bottom-0 w-full border-t bg-zinc-100 pb-safe dark:border-zinc-800 dark:bg-zinc-900'>
 				<div className='mx-auto flex h-16 max-w-md items-center justify-around px-6'>
 					{links.map(({ href, label, icon }) => (
-						<Link key={label} href={href}>
-							<a
-								className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${
-									router.pathname === href
-										? 'text-indigo-500 dark:text-indigo-400'
-										: 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
-								}`}
-							>
-								{icon}
-								<span className='text-xs text-zinc-600 dark:text-zinc-400'>
-									{label}
-								</span>
-							</a>
-						</Link>
+						(<Link
+                            key={label}
+                            href={href}
+                            className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${
+                                router.pathname === href
+                                    ? 'text-indigo-500 dark:text-indigo-400'
+                                    : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+                            }`}>
+
+                            {icon}
+                            <span className='text-xs text-zinc-600 dark:text-zinc-400'>
+                                {label}
+                            </span>
+
+                        </Link>)
 					))}
 				</div>
 			</nav>
 		</div>
-	)
+    )
 }
 
 export default BottomNav

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -5,30 +5,29 @@ const BottomNav = () => {
 	const router = useRouter()
 
 	return (
-        <div className='sm:hidden'>
+		<div className='sm:hidden'>
 			<nav className='fixed bottom-0 w-full border-t bg-zinc-100 pb-safe dark:border-zinc-800 dark:bg-zinc-900'>
 				<div className='mx-auto flex h-16 max-w-md items-center justify-around px-6'>
 					{links.map(({ href, label, icon }) => (
-						(<Link
-                            key={label}
-                            href={href}
-                            className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${
-                                router.pathname === href
-                                    ? 'text-indigo-500 dark:text-indigo-400'
-                                    : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
-                            }`}>
-
-                            {icon}
-                            <span className='text-xs text-zinc-600 dark:text-zinc-400'>
-                                {label}
-                            </span>
-
-                        </Link>)
+						<Link
+							key={label}
+							href={href}
+							className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${
+								router.pathname === href
+									? 'text-indigo-500 dark:text-indigo-400'
+									: 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+							}`}
+						>
+							{icon}
+							<span className='text-xs text-zinc-600 dark:text-zinc-400'>
+								{label}
+							</span>
+						</Link>
 					))}
 				</div>
 			</nav>
 		</div>
-    )
+	)
 }
 
 export default BottomNav


### PR DESCRIPTION
Starting with Next.js 13, `<Link>` renders as `<a>`, so attempting to use `<a>` as a child is invalid and is giving me an error.

I've ran the suggested command from the nextjs docs: `npx @next/codemod new-link .` and this now is working again/

See https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor for details